### PR TITLE
Fix prepopulated fixtures

### DIFF
--- a/apps/prepopulate/test.json
+++ b/apps/prepopulate/test.json
@@ -35,6 +35,6 @@
     "data": {
         "title": "title: end to end closed",
         "description": "description: end to end closed",
-        "state": "closed"
+        "blog_status": "closed"
     }
 }]

--- a/fig.yml
+++ b/fig.yml
@@ -19,6 +19,7 @@ api:
   environment:
    - SUPERDESK_URL
    - SUPERDESK_CLIENT_URL
+   - SUPERDESK_TESTING
    - MONGOLAB_URI=mongodb://db:27017/test
    - LEGAL_ARCHIVEDB_PORT=mongodb://db:27017
    - ELASTICSEARCH_URL=http://elastic:9200


### PR DESCRIPTION
- Fixtures updated with the new status name `blog_status`
- `SUPERDESK_TESTING` added to fig to allow this kind of command:   
```bash
$ SUPERDESK_TESTING=true fig up
```