### PR TITLE
Blog: allowing `versioncreated` in the request

### DIFF
--- a/liveblog/blogs/blogs.py
+++ b/liveblog/blogs/blogs.py
@@ -24,6 +24,7 @@ class BlogsResource(Resource):
         'settings': {'type': 'dict'},
         'original_creator': metadata_schema['original_creator'],
         'version_creator': metadata_schema['version_creator'],
+        'versioncreated': metadata_schema['versioncreated'],
         'blog_status': {
             'type': 'string',
             'allowed': ['open', 'closed'],


### PR DESCRIPTION
Allows `versioncreated` attribute for blog's endpoint.
Even it this field is overwrited after an update, this avoid us to remove this field before resending the request.